### PR TITLE
Replace /dev/stdout w/ open stdout filenumber

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,6 +7,7 @@
 
 ** Manual Updates to the rc database
 
+#+BEGIN_SRC bash
 dc pull
 dc down
 update .env for testing
@@ -39,6 +40,8 @@ insert { graph experts_iam: {person:1b9f745893ea8c821a3fc847e9775dbe a vivo:Facu
 WHERE {}'
 
 dc exec harvest harvest rm $db
+
+#+END_SRC
 
 *** Exporting data
 

--- a/ucdid
+++ b/ucdid
@@ -361,7 +361,7 @@ function fetch() {
 
   local envelope=''
   local search=''
-  local output=/dev/stdout
+  local output
   declare -A CMD;
   while true; do
 	  case $1 in
@@ -406,6 +406,8 @@ function fetch() {
     fi
   done
 
+  # Redirect if need be
+  [[ -n "$output" ]] && exec 1>$output
   # They all get added together, IDK, might work?
   for i in "$@"; do
     fetch="http ${url[$1]} Content-Type:application/json key==${key} v==1.0"
@@ -423,19 +425,21 @@ function fetch() {
   done |
     case ${mime[${G[ucdid_fetch_format]}]} in
       application/json)
-        cat - > ${output}
+        cat -
         shift;;
       application/ld+json)
         log -v ${G[util_jq]} "${G[fetch_context]}"' + {"@graph":.}|del(.["@graph"][].ppsAssociationsResults[]?.iamId)' ' | '${G[util_riot]}' --formatted=jsonld --syntax=jsonld'
-        ${G[util_jq]} "${G[fetch_context]}"' + {"@graph":.}|del(.["@graph"][].ppsAssociationsResults[]?.iamId)' | ${G[util_riot]} --formatted=jsonld --syntax=jsonld > ${output}
+        ${G[util_jq]} "${G[fetch_context]}"' + {"@graph":.}|del(.["@graph"][].ppsAssociationsResults[]?.iamId)' | ${G[util_riot]} --formatted=jsonld --syntax=jsonld
         shift;;
       text/turtle)
         log -v ${G[util_jq]} "${G[fetch_context]}"' + {"@graph":.}|del(.["@graph"][].ppsAssociationsResults[]?.iamId)' ' | '"${G[util_riot]} --formatted=ttl --syntax=jsonld"
-        ${G[util_jq]} "${G[fetch_context]}"' + {"@graph":.}|del(.["@graph"][].ppsAssociationsResults[]?.iamId)' | ${G[util_riot]} --formatted=ttl --syntax=jsonld > ${output}
+        ${G[util_jq]} "${G[fetch_context]}"' + {"@graph":.}|del(.["@graph"][].ppsAssociationsResults[]?.iamId)' | ${G[util_riot]} --formatted=ttl --syntax=jsonld
         shift;;
       *)
         err 1 ${G[ucid_fetch_format]} is invalid format
     esac
+
+  [[ -n $output ]] && exec 1>&-
 }
 
 : <<=cut


### PR DESCRIPTION
Using `/dev/stdout` causes issues in chaining ucdid.  For example 

```bash
  { echo quinn; ./ucdid fetch --search=userId=quinn profiles; echo isgreat; } > quinn.out
```

fails as the intermediate `ucdid` command doesn't respect the parent's stdout.  This patch replaces `/dev/stdout` with the parent stdout.  So the above works, and this works as well

```bash
  { echo quinn; ./ucdid fetch --output=ucdid.json --search=userId=quinn profiles; echo isgreat; } > quinn.out
```

